### PR TITLE
Remove extraneous `end` keyword

### DIFF
--- a/CraftStore.lua
+++ b/CraftStore.lua
@@ -513,7 +513,7 @@ function CS.Queue()
       end
     end
     if ZO_Provisioner_IsSceneShowing() and CS.Account.options.usecook then
-      ZO_ProvisionerTopLevelTooltip:SetHidden(true) end
+      ZO_ProvisionerTopLevelTooltip:SetHidden(true)
       if PP ~= nil then ZO_ProvisionerTopLevel:SetHidden(true) end
     end
     if CS.Inspiration ~= '' then


### PR DESCRIPTION
This is causing the addon to throw an error on load that hangs the entire game requiring the user to end the task and disable the addon or manually patch.