### PR TITLE
Fix motif style knowledge detection for U33

### DIFF
--- a/CraftStoreFixedAndImproved.txt
+++ b/CraftStoreFixedAndImproved.txt
@@ -5,8 +5,8 @@
 ; You can read the full terms at https://account.elderscrollsonline.com/add-on-terms
 
 ## Title: CraftStore
-## APIVersion: 101032
-## Version: 2.75.1
+## APIVersion: 101033
+## Version: 2.76
 ## SavedVariables: CraftStore_Account CraftStore_Character
 ## Author: AlphaLemming, BlackSwan, Rhyono
 ## Description: A tool for crafting research, with style and recipe tracking and new crafting interfaces. 

--- a/CraftStore_Styles.lua
+++ b/CraftStore_Styles.lua
@@ -336,8 +336,8 @@ function CS.STYLE()
 				return IsItemLinkBookKnown(('|H1:item:%u:6:1:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0|h|h'):format(styles[style][3]))
 			else      
 				for chapter = 1,14 do
-					local _, known = GetAchievementCriterion(styles[style][2],chapter)
-					if known == 0 then return false end
+					local known = self.IsKnownStyle(style,chapter)
+					if not known then return false end
 				end
 			return true
 			end
@@ -360,11 +360,18 @@ function CS.STYLE()
 			if self.IsCrownStyle(style) then
 				return IsItemLinkBookKnown(('|H1:item:%u:6:1:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0|h|h'):format(styles[style][3]))
 			else  
-				local _, known = GetAchievementCriterion(styles[style][2],chapter)
-				if known == 1 then return true end
+			    local categoryIndex, collectionIndex = self.GetLoreBookIndicesForStyle(style)
+				local _, _, known = GetLoreBookInfo(categoryIndex, collectionIndex, chapter)
+				return known
 			end
 		end
 		return false
+	end
+	
+	function self.GetLoreBookIndicesForStyle(style)
+		local achievementId = styles[style][2]
+		local collectionId = GetAchievementLinkedBookCollectionId(achievementId)
+		return GetLoreBookCollectionIndicesFromCollectionId(collectionId)
 	end
   
 	function self.UpdatePreview(preview)

--- a/CraftStore_Styles.lua
+++ b/CraftStore_Styles.lua
@@ -360,7 +360,7 @@ function CS.STYLE()
 			if self.IsCrownStyle(style) then
 				return IsItemLinkBookKnown(('|H1:item:%u:6:1:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0|h|h'):format(styles[style][3]))
 			else  
-			    local categoryIndex, collectionIndex = self.GetLoreBookIndicesForStyle(style)
+				local categoryIndex, collectionIndex = self.GetLoreBookIndicesForStyle(style)
 				local _, _, known = GetLoreBookInfo(categoryIndex, collectionIndex, chapter)
 				return known
 			end

--- a/CraftStore_VarInit.lua
+++ b/CraftStore_VarInit.lua
@@ -4,7 +4,7 @@ CS.Debug = (GetWorldName() == "PTS" or GetDisplayName()=="@VladislavAksjonov")
 CS.Name = 'CraftStoreFixedAndImproved'
 CS.Title = 'CraftStore'
 CS.Author = 'AlphaLemming, BlackSwan, Rhyono'
-CS.Version = '2.75.1'
+CS.Version = '2.76'
 CS.Account = nil
 CS.Character = nil
 CS.Init = false


### PR DESCRIPTION
Since the introduction of account wide achievements in update 33 all characters share the
achievement progress for motif style achievements. This leads to several issues regarding
the detection, the current character knows a certain motif chapter or not.
The new way to check for knowledge of the chapter is to check, if the associated style
book is known.

The API update introduced a new function
`GetAchievementLinkedBookCollectionId(achievementId)` which is used to bridge the gap
to the book collection. This allows us to continue using the achievement IDs instead of
listing up all book collections manually.