### PR TITLE
Fix highlighting of tracked study lines in U34

### DIFF
--- a/CraftStore.lua
+++ b/CraftStore.lua
@@ -806,7 +806,7 @@ function CS.UpdateStudyLine(control,tracking,craft,line)
   -- set all tracked
   if allTracked then
     control:GetNamedChild('HeaderTexture'):SetColor(1,1,1,1)
-    for x = 1, control:GetNumChildren() - 1 do
+    for x = 2, control:GetNumChildren() - 1 do
       local subcontrol = control:GetChild(x)
       subcontrol:SetCenterColor(0.06,0.06,0.06,1)
       subcontrol:SetEdgeColor(1,1,1,0.12)
@@ -814,7 +814,7 @@ function CS.UpdateStudyLine(control,tracking,craft,line)
   else
     -- set header red
     control:GetNamedChild('HeaderTexture'):SetColor(1,0,0,1)
-    for x = 1, control:GetNumChildren() - 1 do
+    for x = 2, control:GetNumChildren() - 1 do
       local subcontrol = control:GetChild(x)
       -- set individually
       if trackingTable[x] then


### PR DESCRIPTION
With the introduction of the new TLC rules in update 34, some
functions seem to have been removed from texture controls
(or were made inaccessible).

This lead to the following UI error:
user:/AddOns/CraftStoreFixedAndImproved/CraftStore.lua:824:
function expected instead of nil

This fix simply removes the additional highlighting from the
study line header that consisted of a red border and
background. The red hue change of the study line's
header icons still remains however, which should be enough
of an indicator to show if the line is fully tracked.