### PR TITLE
Add filter on startup to remove unpublished styles and furnishings

### DIFF
--- a/CraftStore_Events.lua
+++ b/CraftStore_Events.lua
@@ -327,12 +327,16 @@ function CS.OnAddOnLoaded(eventCode,addOnName)
   if addOnName ~= CS.Name then return end
   
   CS.Style = CS.STYLE()
+  CS.Style.RemoveUnpublishedStyles()
   CS.Style.CompileStyles()
   CS.Style.CompilePartialStyles({[114]=true,[119]=true})
   CS.Crafting.CompileTraits()
   --cs_flask = CS.CS.Flask()  
   CS.Account = ZO_SavedVars:NewAccountWide('CraftStore_Account',3,GetWorldName(),CS.AccountInit)
   CS.Character = ZO_SavedVars:NewCharacterIdSettings('CraftStore_Character',2,GetWorldName(),CS.CharInit)
+
+  -- remove unpublished furnishing recipies
+  CS.Furnisher.recipelist = CS.FilterPublishedItems(CS.Furnisher.recipelist)
 
 	--build schema for data
 	LBE:DefinePrefix("CSCK28",CS.Name,CS.LBE.Cook,64,LBE:ConvertTable(LBE:ConcatTables(CS.Cook.recipelist,CS.Cook.recipeduplicatelist)))

--- a/CraftStore_Helpers.lua
+++ b/CraftStore_Helpers.lua
@@ -131,6 +131,26 @@ function CS.NilCheckSetIfNil(root,default,...)
 	return root
 end
 
+function CS.IsPublishedItem(itemId)
+  local itemName = GetItemLinkName(('|H1:item:%u:6:1:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0|h|h'):format(itemId))
+  return itemName ~= nil and itemName ~= ''
+end
+
+function CS.IsPublishedAchievement(achievementId)
+  local achievementName = GetAchievementName(achievementId)
+  return achievementName ~= nil and achievementName ~= ''
+end
+
+function CS.FilterPublishedItems(itemIds)
+  local publishedItemIds = {}
+  for i,itemId in pairs(itemIds) do
+    if CS.IsPublishedItem(itemId) then
+      table.insert(publishedItemIds, itemId)
+    end
+  end
+  return publishedItemIds
+end
+
 CS.Chat = {}
 
 function CS.Chat:Print(str)

--- a/CraftStore_Styles.lua
+++ b/CraftStore_Styles.lua
@@ -122,7 +122,7 @@ function CS.STYLE()
 	[124] = {2,3097,178505}, -- Silver Rose
 	[125] = {2,3098,178529}, -- Annihilarch's Chosen
 	[126] = {2,3220,178707}, -- Fargrave Guardian
-	[127] = {2,3228,181662}, -- Dreadsails
+	[128] = {2,3228,181662}, -- Dreadsails
 	[129] = {2,3229,181679}, -- Ascendant Order
 	--[130] = {2,0,   182521}, -- Syrabanic Marine
 	[131] = {2,3259,182538}, -- Steadfast Society

--- a/CraftStore_Styles.lua
+++ b/CraftStore_Styles.lua
@@ -266,7 +266,7 @@ function CS.STYLE()
 				table.insert(unpublishedStyles,style)
 			end
 			-- non-crown styles must have an known achievement attached
-			if not CS.IsPublishedAchievement(styles[style][2]) then
+			if (not self.IsCrownStyle(style)) and (not CS.IsPublishedAchievement(styles[style][2])) then
 				table.insert(unpublishedStyles,style)
 			end	
 		end

--- a/CraftStore_Styles.lua
+++ b/CraftStore_Styles.lua
@@ -256,6 +256,26 @@ function CS.STYLE()
 		local styleVisualId = styleName:match("%d+")
 		styles[style][4] = styleVisualId ~= nil and styleVisualId or 0 
 	end
+	
+	-- remove unpublished styles to avoid hickups
+	function self.RemoveUnpublishedStyles()
+		local unpublishedStyles = {}
+		for style,data in pairs(styles) do
+			-- every style must have a known representative item
+			if not CS.IsPublishedItem(styles[style][3]) then
+				table.insert(unpublishedStyles,style)
+			end
+			-- non-crown styles must have an known achievement attached
+			if not CS.IsPublishedAchievement(styles[style][2]) then
+				table.insert(unpublishedStyles,style)
+			end	
+		end
+		
+		for i,style in pairs(unpublishedStyles) do
+			styles[style] = nil
+			style_map[style] = nil
+		end
+	end
   
 	--build flattened complete style list
 	function self.CompileStyles()


### PR DESCRIPTION
In order to avoid the additional effort to check which styles made it
from a PTS to the live version, an initial filtering has been added
that checks that each style has an existing reference item and
a linked achievement (except crown store styles).

Similarly, the list of furnishing recipies is filtered and all unknown
recipies are removed from the list as well.

This change should also allow publishing now allow for the
publishing of CrownStore updates before the release
of a new major ESO update, provided it does not contain any
breaking changes regarding the API.