### PR TITLE
Bring windows to the top when opening them

### DIFF
--- a/CraftStore.lua
+++ b/CraftStore.lua
@@ -4327,6 +4327,9 @@ function CS.ControlShow(scene)
   end
   if closed then
     scene:SetHidden(false)
+    if scene:GetType() == CT_TOPLEVELCONTROL then
+      scene:BringWindowToTop()
+    end
   end
 end
 


### PR DESCRIPTION
With update 34 and the changes to the GUI rendering, windows that
were opened (switched from hidden to visible) were placed behind
the CraftStore main window.

This change brings all TopLevelControls to the top when they
are shown through their associated buttons. Afterwards, the layering
is controled by window focus, i.e. when you click a window, it is
brought to the top as expected.