### PR TITLE
Fix misaligned tracking markers

### DIFF
--- a/CraftStore.lua
+++ b/CraftStore.lua
@@ -817,7 +817,7 @@ function CS.UpdateStudyLine(control,tracking,craft,line)
     for x = 2, control:GetNumChildren() - 1 do
       local subcontrol = control:GetChild(x)
       -- set individually
-      if trackingTable[x] then
+      if trackingTable[x-1] then
         subcontrol:SetCenterColor(0.06,0.06,0.06,1)
         subcontrol:SetEdgeColor(1,1,1,0.12)
       else


### PR DESCRIPTION
A previous bugfix that addressed a change to the way
child controls are enumerated update 34 included
a change to the start index for the trait controls within a
research line. That fix introduced an off-by-one error
when selecting the tracking information for the trait
which lead to CraftStore marking the wrong trait cell
after clicking it.

This change now fixes this off-by-one error by applying
the required offset to align with the tracking table.