### PR TITLE
Fix sorting by motif number

### DIFF
--- a/CraftStore_Styles.lua
+++ b/CraftStore_Styles.lua
@@ -266,7 +266,7 @@ function CS.STYLE()
 	for style,data in pairs(styles) do
 		local styleName = GetItemLinkName(('|H1:item:%u:6:1:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0|h|h'):format(styles[style][3]))
 		local styleVisualId = styleName:match("%d+")
-		styles[style][4] = styleVisualId ~= nil and styleVisualId or 0 
+		styles[style][4] = styleVisualId ~= nil and tonumber(styleVisualId) or 0 
 	end
 	
 	-- remove unpublished styles to avoid hickups


### PR DESCRIPTION
When parsing the motif number from the motif style name, the number could previously parsed as a number or a string which lead to issues when trying to sort the motif list by this value.

The motif number is now always explicitly parsed to a number.