### PR TITLE
Fix alignment of setting buttons in recipe list

### DIFF
--- a/XML/UI/CraftStore_Recipe.xml
+++ b/XML/UI/CraftStore_Recipe.xml
@@ -21,15 +21,15 @@
               <Dimensions x="580" y="40"/>
               <Edge edgeSize="1"/>
             </Backdrop>
-            <Button name="$(parent)HideKnownButton" clickSound="Click" verticalAlignment="1" font="CraftStoreFixedFont">
+            <Button name="$(parent)HideKnownButton" clickSound="Click" horizontalAlignment="RIGHT" verticalAlignment="1" font="CraftStoreFixedFont">
               <FontColors normalColor="E8DFAF"/>
-              <Anchor point="LEFT" relativePoint="LEFT" offsetY="-10" offsetX="130" relativeTo="$(parent)TopSection"/>
+              <Anchor point="LEFT" relativePoint="LEFT" offsetY="-10" offsetX="105" relativeTo="$(parent)TopSection"/>
               <Dimensions y="22" x="300"/>
               <OnClicked>CraftStoreFixedAndImprovedLongClassName.HideKnownRecipes()</OnClicked>
             </Button>
-            <Button name="$(parent)HideUnknownButton" clickSound="Click" verticalAlignment="1" font="CraftStoreFixedFont">
+            <Button name="$(parent)HideUnknownButton" clickSound="Click" horizontalAlignment="RIGHT" verticalAlignment="1" font="CraftStoreFixedFont">
               <FontColors normalColor="E8DFAF"/>
-              <Anchor point="LEFT" relativePoint="LEFT" offsetY="10" offsetX="130" relativeTo="$(parent)TopSection"/>
+              <Anchor point="LEFT" relativePoint="LEFT" offsetY="10" offsetX="105" relativeTo="$(parent)TopSection"/>
               <Dimensions y="22" x="300"/>
               <OnClicked>CraftStoreFixedAndImprovedLongClassName.HideUnknownRecipes()</OnClicked>
             </Button>			


### PR DESCRIPTION
The buttons have previously been centered within their bounding box, often leading to overlapping with the window title.

This change now aligns both buttons to the right, directly next to the search box.

Changelog: fixed