### PR TITLE
Fix broken recipe sorting for russian clients by searching for alternative spellings of resource names

### DIFF
--- a/CraftStore.lua
+++ b/CraftStore.lua
@@ -1069,6 +1069,36 @@ function CS.UpdateRecipeKnowledge()
       end
     end
     local fm,fs,fh = statcheck(CS.MagickaName), statcheck(CS.StaminaName), statcheck(CS.HealthName)
+
+    -- Check for alternative resource names in the description
+    -- Some languages may have different spellings of the resource between the description and
+    -- when only mentioning the resource alone. This is currently only known for russian clients.
+    if CS.Loc.alternativeResourceNames then
+      if not fh then
+        for i, alternativeName in pairs(CS.Loc.alternativeResourceNames[SI_ATTRIBUTES1]) do
+          if statcheck(alternativeName) then
+            fh = true
+          end
+        end
+      end
+      
+      if not fm then
+        for i, alternativeName in pairs(CS.Loc.alternativeResourceNames[SI_ATTRIBUTES2]) do
+          if statcheck(alternativeName) then
+            fm = true
+          end
+        end
+      end
+      
+      if not fs then
+        for i, alternativeName in pairs(CS.Loc.alternativeResourceNames[SI_ATTRIBUTES3]) do
+          if statcheck(alternativeName) then
+            fs = true
+          end
+        end
+      end
+    end 
+    
     if fm and fh and fs then
       stat = 7
     elseif fs and fh then
@@ -4573,6 +4603,7 @@ if CS.Debug then
   SLASH_COMMANDS["/langfr"] = function() SetCVar("language.2", "fr") end
   SLASH_COMMANDS["/langen"] = function() SetCVar("language.2", "en") end
   SLASH_COMMANDS["/langde"] = function() SetCVar("language.2", "de") end
+  SLASH_COMMANDS["/langru"] = function() SetCVar("language.2", "ru") end
 end
 
 SLASH_COMMANDS["/cs"] = CS.ShowMain

--- a/CraftStoreFixedAndImproved.txt
+++ b/CraftStoreFixedAndImproved.txt
@@ -5,8 +5,8 @@
 ; You can read the full terms at https://account.elderscrollsonline.com/add-on-terms
 
 ## Title: CraftStore
-## APIVersion: 101038 101037
-## Version: 2.86
+## APIVersion: 101038
+## Version: 2.87
 ## SavedVariables: CraftStore_Account CraftStore_Character
 ## Author: AlphaLemming, BlackSwan, Rhyono
 ## Description: A tool for crafting research, with style and recipe tracking and new crafting interfaces. 

--- a/CraftStore_Lang.lua
+++ b/CraftStore_Lang.lua
@@ -617,6 +617,18 @@ ru = {
 		'|cE8DFAF'..mmb..' исследовать|r',
 		'|cE8DFAF'..lmb..' трек|r',		
 	},
+	alternativeResourceNames = {
+		[SI_ATTRIBUTES1] = {
+			[0] = 'здоровья'
+		},
+		[SI_ATTRIBUTES2] = {
+			[0] = 'магии'
+		},
+		[SI_ATTRIBUTES3] = {
+			[0] = 'запас сил',
+			[1] = 'запаса сил'
+		},
+	},
 	nobagspace = '|cFF0000Недостаточно места!|r',
 	noSlot = '|cFF0000Нет свободного слота для исследования или предмет недоступен!|r',
 	noItemPreview = '|cFF0000Требуется аддон ItemPreview!|r',

--- a/CraftStore_VarInit.lua
+++ b/CraftStore_VarInit.lua
@@ -1,4 +1,4 @@
-﻿CS = CraftStoreFixedAndImprovedLongClassName
+CS = CraftStoreFixedAndImprovedLongClassName
 
 CS.Debug = (GetWorldName() == "PTS" or GetDisplayName()=="@VladislavAksjonov")
 CS.Name = 'CraftStoreFixedAndImproved'

--- a/CraftStore_VarInit.lua
+++ b/CraftStore_VarInit.lua
@@ -4,7 +4,7 @@ CS.Debug = (GetWorldName() == "PTS" or GetDisplayName()=="@VladislavAksjonov")
 CS.Name = 'CraftStoreFixedAndImproved'
 CS.Title = 'CraftStore'
 CS.Author = 'AlphaLemming, BlackSwan, Rhyono'
-CS.Version = '2.86'
+CS.Version = '2.87'
 CS.Account = nil
 CS.Character = nil
 CS.Init = false


### PR DESCRIPTION
Due to some quirks in the russian language or cyrillic alphabet, the resource names do not appear
the same way in recipe descriptions as they do in other parts of the game, leading to missmatching
when sorting the recipes in the different categories.

This change introduces a list of alternative resource names in the language file which will be used
for additional matching attempts if it is present.

Changelog: fixed

---

Includes version bump