### PR TITLE
Disable hiding of CraftstoreCook when clicking the fillet button in gamepad mode

### DIFF
--- a/CraftStore.lua
+++ b/CraftStore.lua
@@ -1888,10 +1888,13 @@ end
 
 
 function CS.CookShowVanilla()
-  CraftStoreFixed_Cook:SetHidden(true)
+  -- CS Cook can remain open in gamepad mode as both remain side by side
+  if not IsInGamepadPreferredMode() then
+    CraftStoreFixed_Cook:SetHidden(true)
+    CS.Cook.job = {amount=0}
+    for x = 1,CraftStoreFixed_CookFoodSectionScrollChild:GetNumChildren() do CS.HideControl('CraftStoreFixed_CookFoodSectionScrollChildButton'..x) end
+  end
   for x = 2, ZO_ProvisionerTopLevel:GetNumChildren() do ZO_ProvisionerTopLevel:GetChild(x):SetAlpha(1) end
-  CS.Cook.job = {amount=0}
-  for x = 1,CraftStoreFixed_CookFoodSectionScrollChild:GetNumChildren() do CS.HideControl('CraftStoreFixed_CookFoodSectionScrollChildButton'..x) end
   ZO_KeybindStripControl:SetHidden(false)
 end
 
@@ -1899,8 +1902,11 @@ function CS.CookShow()
   CraftStoreFixed_CookAmount:SetText('')
   CraftStoreFixed_CookSearch:SetText(GetString(SI_GAMEPAD_HELP_SEARCH)..'...')
   CraftStoreFixed_Cook:SetHidden(false)
-  for x = 2, ZO_ProvisionerTopLevel:GetNumChildren() do ZO_ProvisionerTopLevel:GetChild(x):SetAlpha(0) end
-  ZO_KeybindStripControl:SetHidden(not IsInGamepadPreferredMode())
+  -- Vanilla UI remains active alongside CS Cook in gamepad mode
+  if not IsInGamepadPreferredMode() then
+    for x = 2, ZO_ProvisionerTopLevel:GetNumChildren() do ZO_ProvisionerTopLevel:GetChild(x):SetAlpha(0) end
+    ZO_KeybindStripControl:SetHidden(true)
+  end
 end
 
 function CS.RuneCreate(control,button)

--- a/CraftStoreFixedAndImproved.txt
+++ b/CraftStoreFixedAndImproved.txt
@@ -6,7 +6,7 @@
 
 ## Title: CraftStore
 ## APIVersion: 101038
-## Version: 2.87
+## Version: 2.88
 ## SavedVariables: CraftStore_Account CraftStore_Character
 ## Author: AlphaLemming, BlackSwan, Rhyono, MuMuQ
 ## Description: A tool for crafting research, with style and recipe tracking and new crafting interfaces. 

--- a/CraftStore_Events.lua
+++ b/CraftStore_Events.lua
@@ -47,7 +47,7 @@ function CS.OnCraftingStationInteract(eventCode,craftSkill)
 	  --Update space
 	  CS.InventorySpace(CraftStoreFixed_CookSpaceButtonName)	  
     
-    if not CS.Cook.hooksInitialized then
+    if not CS.Cook.hooksInitialized and not IsInGamepadPreferredMode() then
       ZO_PreHookHandler(ZO_ProvisionerTopLevelTabsButton2,'OnMouseDown', CS.CookFoodTabShow)
       ZO_PreHookHandler(ZO_ProvisionerTopLevelTabsButton3,'OnMouseDown', CS.CookDrinkTabShow)
       ZO_PreHookHandler(ZO_ProvisionerTopLevelTabsButton4,'OnMouseDown', CS.CookFurnitureTabShow)

--- a/CraftStore_VarInit.lua
+++ b/CraftStore_VarInit.lua
@@ -4,7 +4,7 @@ CS.Debug = (GetWorldName() == "PTS" or GetDisplayName()=="@VladislavAksjonov")
 CS.Name = 'CraftStoreFixedAndImproved'
 CS.Title = 'CraftStore'
 CS.Author = 'AlphaLemming, BlackSwan, Rhyono, MuMuQ'
-CS.Version = '2.87'
+CS.Version = '2.88'
 CS.Account = nil
 CS.Character = nil
 CS.Init = false


### PR DESCRIPTION
…amepad mode

As the gamepad UI's control names differ from the keyboard UI, the hooks for the tab selector buttons failed to register, leading to UI errors for gamepad users.

With this change the hooks will only be registered for keyboard users and CSCook will remain opened along the gamepad cooking menu, as it already did before with all other functionality.

Changelog: fixed