### PR TITLE
Fix swapped jewelry indices

### DIFF
--- a/CraftStore.lua
+++ b/CraftStore.lua
@@ -436,7 +436,7 @@ function CS.IsLocked(bagId,slotIndex)
   end
   -- Determine equip type
   local isJewelry = false
-  if equipType == EQUIP_TYPE_NECK or equipType == EQUIP_TYPE_RING then
+  if equipType == EQUIP_TYPE_RING or equipType == EQUIP_TYPE_NECK then
     isJewelry = true
   end
 
@@ -3187,9 +3187,9 @@ function CS.GetTrait(link)
     line=7
   end
   --Handle Jewelry
-  if eq==EQUIP_TYPE_NECK or eq==EQUIP_TYPE_RING then
+  if eq==EQUIP_TYPE_RING or eq==EQUIP_TYPE_NECK then
     craft=7
-    line = eq==EQUIP_TYPE_NECK and 1 or 2
+    line = eq==EQUIP_TYPE_RING and 1 or 2
     --No real order to jewelry traits
     if trait==ITEM_TRAIT_TYPE_JEWELRY_ARCANE then
       trait=1
@@ -3244,8 +3244,8 @@ function CS.IsValidEquip(equip)
   or equip==EQUIP_TYPE_TWO_HAND
   or equip==EQUIP_TYPE_SHOULDERS
   or equip==EQUIP_TYPE_WAIST
-  or equip==EQUIP_TYPE_NECK
   or equip==EQUIP_TYPE_RING
+  or equip==EQUIP_TYPE_NECK
   then return true else return false end
 end
 


### PR DESCRIPTION
With Gold Road, the indices of rings and necklaces for the crafting bench changed.

Here's what still worked with this change:

- Checkmarks for learned traits are still shown correctly

Here's what the change broke:

- Tooltips have wrong information (e.g. a ring might show as not yet researched when it's actually the necklace that's missing)
- Wrong items are marked in the CraftStore grid as being available in inventory (e.g. it might show a exemplary ring from your inventory when hovering over the missing necklace trait)
- No jewelry items can be researched via the CraftStore interface anymore whatsoever (via middle mouse button), even when there is a suitable item and even when the trait is missing for both ring and necklace (e.g. it tries to use a ring item to research a necklace trait and failed with "No free research slot or item inaccessible!" error)

According to my tests, the change in line 3192 fixed all three issues. Unless there's any additional bugs that I didn't test, the change should fix all jewelry again.

The remaining changes are merely to keep all mentions of rings and necklaces in the code consistent with the new order, but aren't actually changing any functionality.