### PR TITLE
Fix swapped indices of jewelry and nirnhoned shields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ luac.out
 
 # Jetbrains IDEs
 .idea
+
+# VSCode
+*.code-workspace
+.history

--- a/CraftStore.lua
+++ b/CraftStore.lua
@@ -3139,7 +3139,7 @@ function CS.GetTrait(link)
   local at,wt,line=GetItemLinkArmorType(link),GetItemLinkWeaponType(link),nil
   if trait==ITEM_TRAIT_TYPE_ARMOR_NIRNHONED then
     trait=19
-    if at == ARMORTYPE_NONE then trait = 9 end
+    if at == ARMORTYPE_NONE then trait = 19 end
   end -- Nirnhoned Weapon replacement
   if trait==ITEM_TRAIT_TYPE_WEAPON_NIRNHONED then
     trait=9
@@ -3170,7 +3170,7 @@ function CS.GetTrait(link)
   elseif wt==WEAPONTYPE_HEALING_STAFF then
     craft=6;line=5;
   elseif wt==WEAPONTYPE_SHIELD then
-    craft=6;line=6;
+    craft=6;line=6;trait=trait-10;
   elseif eq==EQUIP_TYPE_CHEST then
     line=1
   elseif eq==EQUIP_TYPE_FEET then

--- a/CraftStore.lua
+++ b/CraftStore.lua
@@ -1813,11 +1813,11 @@ function CS.CookShowCategory(list,override)
         for list_num=1,#lists do
           local _,num,_,_,_,_,sound = GetRecipeListInfo(lists[list_num])
           for id = num, 1, -1 do
-            local _, name = GetRecipeInfo(lists[list_num],id)
+            local _, recipe_name = GetRecipeInfo(lists[list_num],id)
             for _, step in pairs(CS.Quest[CRAFTING_TYPE_PROVISIONING].work) do
               --Remove hyphens, capitalization and control characters
               local temp_step = step:gsub("-"," "):gsub("%^%a*",""):lower()
-              local temp_name = name:gsub("-"," "):gsub("%^%a*",""):lower()
+              local temp_name = recipe_name:gsub("-"," "):gsub("%^%a*",""):lower()
               --German adjustments
               if lang == 'de' then
                 --Remove trailing s

--- a/CraftStore.lua
+++ b/CraftStore.lua
@@ -3170,7 +3170,7 @@ function CS.GetTrait(link)
   elseif wt==WEAPONTYPE_HEALING_STAFF then
     craft=6;line=5;
   elseif wt==WEAPONTYPE_SHIELD then
-    craft=6;line=6;trait=trait-10;
+    craft=6;line=6;
   elseif eq==EQUIP_TYPE_CHEST then
     line=1
   elseif eq==EQUIP_TYPE_FEET then

--- a/CraftStore.lua
+++ b/CraftStore.lua
@@ -436,7 +436,7 @@ function CS.IsLocked(bagId,slotIndex)
   end
   -- Determine equip type
   local isJewelry = false
-  if equipType == EQUIP_TYPE_NECK or equipType == EQUIP_TYPE_RING then
+  if equipType == EQUIP_TYPE_RING or equipType == EQUIP_TYPE_NECK then
     isJewelry = true
   end
 
@@ -3187,9 +3187,9 @@ function CS.GetTrait(link)
     line=7
   end
   --Handle Jewelry
-  if eq==EQUIP_TYPE_NECK or eq==EQUIP_TYPE_RING then
+  if eq==EQUIP_TYPE_RING or eq==EQUIP_TYPE_NECK then
     craft=7
-    line = eq==EQUIP_TYPE_NECK and 1 or 2
+    line = eq==EQUIP_TYPE_RING and 1 or 2
     --No real order to jewelry traits
     if trait==ITEM_TRAIT_TYPE_JEWELRY_ARCANE then
       trait=1
@@ -3244,8 +3244,8 @@ function CS.IsValidEquip(equip)
   or equip==EQUIP_TYPE_TWO_HAND
   or equip==EQUIP_TYPE_SHOULDERS
   or equip==EQUIP_TYPE_WAIST
-  or equip==EQUIP_TYPE_NECK
   or equip==EQUIP_TYPE_RING
+  or equip==EQUIP_TYPE_NECK
   then return true else return false end
 end
 

--- a/CraftStoreFixedAndImproved.txt
+++ b/CraftStoreFixedAndImproved.txt
@@ -19,6 +19,7 @@ XML/UI/CraftStore_Font.xml
 CraftStore_VarInit.lua
 ;CraftStore_Flask.lua
 CraftStore_Styles.lua
+CraftStore_Migrations.lua
 CraftStore.lua
 ;CraftStore_MainMenu.lua
 CraftStore_LAM.lua

--- a/CraftStore_Events.lua
+++ b/CraftStore_Events.lua
@@ -360,6 +360,11 @@ function CS.OnAddOnLoaded(eventCode,addOnName)
   CS.Account = ZO_SavedVars:NewAccountWide('CraftStore_Account',3,GetWorldName(),CS.AccountInit)
   CS.Character = ZO_SavedVars:NewCharacterIdSettings('CraftStore_Character',2,GetWorldName(),CS.CharInit)
 
+  if CS.Account.crafting.jewelryIdSwapMigrationAlreadyDone == nil or CS.Account.crafting.jewelryIdSwapMigrationAlreadyDone == false then
+    CS.MigrateJewelryIdSwap()
+    CS.Account.crafting.jewelryIdSwapMigrationAlreadyDone = true
+  end
+
   -- remove unpublished furnishing recipies
   CS.Furnisher.recipelist = CS.FilterPublishedItems(CS.Furnisher.recipelist)
 

--- a/CraftStore_Events.lua
+++ b/CraftStore_Events.lua
@@ -360,9 +360,18 @@ function CS.OnAddOnLoaded(eventCode,addOnName)
   CS.Account = ZO_SavedVars:NewAccountWide('CraftStore_Account',3,GetWorldName(),CS.AccountInit)
   CS.Character = ZO_SavedVars:NewCharacterIdSettings('CraftStore_Character',2,GetWorldName(),CS.CharInit)
 
+  if CS.Debug then zo_callLater(function() CHAT_ROUTER:AddSystemMessage("CS.Account.crafting.jewelryIdSwapMigrationAlreadyDone: "..tostring(CS.Account.crafting.jewelryIdSwapMigrationAlreadyDone)) end, 50) end
   if CS.Account.crafting.jewelryIdSwapMigrationAlreadyDone == nil or CS.Account.crafting.jewelryIdSwapMigrationAlreadyDone == false then
+    zo_callLater(
+            function()
+                CHAT_ROUTER:AddSystemMessage("[CraftStore] The internal indices of the game for jewelry (rings and necklaces) got swapped by ZOS. CraftStore need to migrate its SavedVariables once. Starting...")
+            end, 50)
     CS.MigrateJewelryIdSwap()
     CS.Account.crafting.jewelryIdSwapMigrationAlreadyDone = true
+    zo_callLater(
+            function()
+                CHAT_ROUTER:AddSystemMessage("[CraftStore] Migration of CraftStore's SavedVariables finished.")
+            end, 50)
   end
 
   -- remove unpublished furnishing recipies

--- a/CraftStore_Flask.lua
+++ b/CraftStore_Flask.lua
@@ -156,7 +156,7 @@ function CraftStoreFixedAndImprovedLongClassName.FLASK()
         else
             for y,x in pairs(plant) do
                 local icon, _, link = self.GetReagent(x)
-                item = item..zo_strformat('|t32:32:<<1>>|t', icon)
+                local item = item..zo_strformat('|t32:32:<<1>>|t', icon)
                 color = color..zo_strformat('<<C:1>>', link)
                 if y < #plant then
                     item = item..' + '

--- a/CraftStore_Helpers.lua
+++ b/CraftStore_Helpers.lua
@@ -165,23 +165,23 @@ end
 
 -- utility function for finding furnishing recipes
 function CS.FindUnidentifiedFurnishingRecipes(startIndex, endIndex)
-	exists = {}
+	local exists = {}
 	for i=1, #CS.Furnisher.recipelist do
 		exists[CS.Furnisher.recipelist[i]]=true
 	end
 
-	unknown = {}
-	j=1
+	local unknown = {}
+	local j=1
 
-	suffix = ":" .. 364 .. ":" .. 50 .. ":0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:10000:0|h|h"
+	local suffix = ":" .. 364 .. ":" .. 50 .. ":0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:10000:0|h|h"
 	
 	d("Searching in range "..startIndex.." .. "..endIndex)
 
 	for i=startIndex, endIndex do
-		isUnknown = false
+		local isUnknown = false
 		if exists[i] == nil then
-			link= "|H1:item:" .. i .. suffix
-			name=GetItemLinkName(link)
+			local link= "|H1:item:" .. i .. suffix
+			local name=GetItemLinkName(link)
 			if string.find(name, "Praxis:") then
 				isUnknown = true
 			elseif string.find(name, "Blueprint:") then
@@ -207,7 +207,7 @@ function CS.FindUnidentifiedFurnishingRecipes(startIndex, endIndex)
 		end
 	end
 	if #unknown > 1 then
-		unknownIds = ""
+		local unknownIds = ""
 		for i=1, #unknown do
 			unknownIds = unknownIds .. unknown[i] ..","
 		end
@@ -224,7 +224,7 @@ function CS.ListWayshrines(startIndex, endIndex)
 		endIndex = GetNumFastTravelNodes()
 	end
 	for i=startIndex, endIndex do
-	    known,name = GetFastTravelNodeInfo(i)
+	    local known,name = GetFastTravelNodeInfo(i)
 		d(i .. ": " .. name)
 	end
 end

--- a/CraftStore_Migrations.lua
+++ b/CraftStore_Migrations.lua
@@ -4,7 +4,8 @@ local CS = CraftStoreFixedAndImprovedLongClassName
 -- Migration of values in CS.Account.crafting.stored[7]
 function CS.MigrateJewelryIdSwap()
     local function LinkedItemIsCheaperThanCurrentItemAndShouldReplaceIt(link, craft, line, trait)
-        local q1, l1, v1 = GetItemLinkQuality(link), GetItemLinkRequiredLevel(link), GetItemLinkRequiredChampionPoints(link)
+        local q1, l1, v1 = GetItemLinkQuality(link), GetItemLinkRequiredLevel(link),
+            GetItemLinkRequiredChampionPoints(link)
 
         -- safety check due to Dragonhold quests
         if CS.NilCheck(CS.Account.crafting.stored, {}, craft, line, trait) == {} then
@@ -54,7 +55,11 @@ function CS.MigrateJewelryIdSwap()
 
     -- safety check
     if CS.Account.crafting.stored[jewelryCraft] == nil then
-        df("CS.Account.crafting.stored[" .. tostring(jewelryCraft) .. "] not accessible. Skipping migration.")
+        zo_callLater(
+            function()
+                CHAT_ROUTER:AddSystemMessage("[CraftStore] !!ERROR!! CS.Account.crafting.stored[" ..
+                    tostring(jewelryCraft) .. "] not accessible. Skipping migration.")
+            end, 50)
         return
     end
 
@@ -68,43 +73,107 @@ function CS.MigrateJewelryIdSwap()
         local oldNecklaceTraitData = CS.Account.crafting.stored[jewelryCraft][oldNecklaceLine][trait]
         local oldRingTraitData = CS.Account.crafting.stored[jewelryCraft][oldRingLine][trait]
 
-        if CS.Debug then 
-            df("trait "..tostring(trait)) 
-            df("line 1: "..tostring(oldNecklaceTraitData))
-            df("line 2: "..tostring(oldRingTraitData))
-        end
+        if CS.Debug then zo_callLater(function() CHAT_ROUTER:AddSystemMessage("trait " .. tostring(trait)) end, 50) end
         local actualLineOfOldNecklaceTraitData, actualLineOfOldRingTraitData = 0, 0
 
         if oldNecklaceTraitData.link ~= nil then
             _, actualLineOfOldNecklaceTraitData, _ = CS.GetTrait(oldNecklaceTraitData.link)
+            if CS.Debug then
+                zo_callLater(
+                    function() CHAT_ROUTER:AddSystemMessage("line 1: " .. tostring(oldNecklaceTraitData.link)) end, 50)
+            end
+        else
+            if CS.Debug then zo_callLater(function() CHAT_ROUTER:AddSystemMessage("line 1: {}") end, 50) end
         end
         if oldRingTraitData.link ~= nil then
             _, actualLineOfOldRingTraitData, _ = CS.GetTrait(oldRingTraitData.link)
+
+            if CS.Debug then
+                zo_callLater(
+                    function() CHAT_ROUTER:AddSystemMessage("line 2: " .. tostring(oldRingTraitData.link)) end, 50)
+            end
+        else
+            if CS.Debug then zo_callLater(function() CHAT_ROUTER:AddSystemMessage("line 2: {}") end, 50) end
         end
 
+        -- ################## Actual migration start here ##################
         if actualLineOfOldNecklaceTraitData == 0 then
-            -- line1 empty and line2 empty skipped, nothing to do
-            if actualLineOfOldRingTraitData ~= 0 then -- line1 empty and line2 not empty
-                if CS.Debug then df("line1 empty and line2 not empty") end
+            -- line1 empty and line2 empty, nothing to do
+            if actualLineOfOldRingTraitData == 0 then 
+                if CS.Debug then
+                    zo_callLater(
+                        function() CHAT_ROUTER:AddSystemMessage("line1 empty and line2 empty, nothing to do") end, 50)
+                end
+
+            -- line1 empty and line2 not empty
+            else
+                if CS.Debug then
+                    zo_callLater(
+                        function() CHAT_ROUTER:AddSystemMessage("line1 empty and line2 not empty") end, 50)
+                end
                 if actualLineOfOldRingTraitData == newRingLine then
-                    if CS.Debug then df("actualLineOfOldRingTraitData: "..tostring(actualLineOfOldRingTraitData).." == newRingLine: "..tostring(newRingLine)) end
+                    if CS.Debug then
+                        zo_callLater(
+                            function()
+                                CHAT_ROUTER:AddSystemMessage("line2 wrong")
+                            end,
+                            50)
+                        zo_callLater(
+                            function() CHAT_ROUTER:AddSystemMessage("moving entry of line2 to line1") end, 50)
+                    end
                     CS.Account.crafting.stored[jewelryCraft][newRingLine][trait] = deepcopy(oldRingTraitData)
                     CS.Account.crafting.stored[jewelryCraft][oldRingLine][trait] = {}
+
+                else 
+                    if CS.Debug then
+                        zo_callLater(
+                            function()
+                                CHAT_ROUTER:AddSystemMessage("line2 correct, nothing to do")
+                            end,
+                            50)
+                    end
                 end
             end
         else
             if actualLineOfOldRingTraitData == 0 then -- line1 not empty and line2 empty
-                if CS.Debug then df("line1 not empty and line2 empty") end
+                if CS.Debug then
+                    zo_callLater(
+                        function() CHAT_ROUTER:AddSystemMessage("line1 not empty and line2 empty") end, 50)
+                end
                 if actualLineOfOldNecklaceTraitData == newNecklaceLine then
-                    if CS.Debug then df("actualLineOfOldNecklaceTraitData: "..tostring(actualLineOfOldNecklaceTraitData).." == newNecklaceLine: "..tostring(newNecklaceLine)) end
+                    if CS.Debug then
+                        zo_callLater(
+                            function()
+                                CHAT_ROUTER:AddSystemMessage("line1 wrong")
+                            end, 50)
+
+                        zo_callLater(
+                            function() CHAT_ROUTER:AddSystemMessage("moving entry of line1 to line2") end, 50)
+                    end
                     CS.Account.crafting.stored[jewelryCraft][newNecklaceLine][trait] = deepcopy(oldNecklaceTraitData)
                     CS.Account.crafting.stored[jewelryCraft][oldNecklaceLine][trait] = {}
+
+                else 
+                    if CS.Debug then
+                        zo_callLater(
+                            function()
+                                CHAT_ROUTER:AddSystemMessage("line1 correct, nothing to do")
+                            end,
+                            50)
+                    end
                 end
             else -- line1 not empty and line2 not empty
-                if CS.Debug then df("line1 not empty and line2 not empty") end
+                if CS.Debug then
+                    zo_callLater(
+                        function() CHAT_ROUTER:AddSystemMessage("line1 not empty and line2 not empty") end, 50)
+                end
                 -- line1 wrong and line2 wrong => swap entries
-                if actualLineOfOldRingTraitData == newNecklaceLine and actualLineOfOldNecklaceTraitData == newRingLine then 
-                    if CS.Debug then df("line1 wrong and line2 wrong => swap entries") end
+                if actualLineOfOldRingTraitData == newNecklaceLine and actualLineOfOldNecklaceTraitData == newRingLine then
+                    if CS.Debug then
+                        zo_callLater(
+                            function() CHAT_ROUTER:AddSystemMessage("line1 wrong and line2 wrong => swap entries") end,
+                            50)
+                    end
                     cache = deepcopy(oldNecklaceTraitData)
                     CS.Account.crafting.stored[jewelryCraft][newRingLine][trait] = deepcopy(oldRingTraitData)
                     CS.Account.crafting.stored[jewelryCraft][newNecklaceLine][trait] = cache
@@ -113,9 +182,27 @@ function CS.MigrateJewelryIdSwap()
                     --   1. Compare entries of line1 and line2. If entry from line1 is cheaper than current entry in line2: replace entry of line2 with entry of line1
                     --   2. Clear line1
                 elseif actualLineOfOldRingTraitData == newNecklaceLine and actualLineOfOldNecklaceTraitData == newNecklaceLine then
-                    if CS.Debug then df("line1 wrong and line2 correct") end
+                    if CS.Debug then
+                        zo_callLater(
+                            function() CHAT_ROUTER:AddSystemMessage("line1 wrong and line2 correct") end, 50)
+                    end
                     if LinkedItemIsCheaperThanCurrentItemAndShouldReplaceIt(oldNecklaceTraitData.link, jewelryCraft, newNecklaceLine, trait) then
+                        if CS.Debug then
+                            zo_callLater(
+                                function() CHAT_ROUTER:AddSystemMessage(
+                                    "line1 cheaper than line2, replacing entry of line2 with line1") end, 50)
+                        end
                         CS.Account.crafting.stored[jewelryCraft][newNecklaceLine][trait] = deepcopy(oldNecklaceTraitData)
+                    else
+                        if CS.Debug then
+                            zo_callLater(
+                                function() CHAT_ROUTER:AddSystemMessage(
+                                    "line2 already cheaper or equal than line1, keeping line2") end, 50)
+                        end
+                    end
+                    if CS.Debug then
+                        zo_callLater(
+                            function() CHAT_ROUTER:AddSystemMessage("clearing line1") end, 50)
                     end
                     CS.Account.crafting.stored[jewelryCraft][oldNecklaceLine][trait] = {}
 
@@ -123,14 +210,40 @@ function CS.MigrateJewelryIdSwap()
                     --   1. Compare entries of line1 and line2. If entry from line2 is cheaper than current entry in line1: replace entry of line1 with entry of line2
                     --   2. Clear line2
                 elseif actualLineOfOldRingTraitData == newRingLine and actualLineOfOldNecklaceTraitData == newRingLine then
-                    if CS.Debug then df("line1 correct and line2 wrong") end
+                    if CS.Debug then
+                        zo_callLater(
+                            function() CHAT_ROUTER:AddSystemMessage("line1 correct and line2 wrong") end, 50)
+                    end
                     if LinkedItemIsCheaperThanCurrentItemAndShouldReplaceIt(oldRingTraitData.link, jewelryCraft, newRingLine, trait) then
+                        if CS.Debug then
+                            zo_callLater(
+                                function() CHAT_ROUTER:AddSystemMessage(
+                                    "line2 cheaper than line1, replacing entry of line1 with line2") end, 50)
+                        end
                         CS.Account.crafting.stored[jewelryCraft][newRingLine][trait] = deepcopy(oldRingTraitData)
+                    else
+                        if CS.Debug then
+                            zo_callLater(
+                                function() CHAT_ROUTER:AddSystemMessage(
+                                    "line1 already cheaper or equal than line2, keeping line1") end, 50)
+                        end
+                    end
+                    if CS.Debug then
+                        zo_callLater(
+                            function() CHAT_ROUTER:AddSystemMessage("clearing line2") end, 50)
                     end
                     CS.Account.crafting.stored[jewelryCraft][oldRingLine][trait] = {}
-                end
+
+                    
                 -- line1 correct and line2 correct => do nothing
+                else 
+                    if CS.Debug then
+                        zo_callLater(
+                            function() CHAT_ROUTER:AddSystemMessage("line1 correct and line2 correct, nothing to do") end, 50)
+                    end
+                end
             end
         end
+        -- ################## End of actual migration ##################
     end
 end

--- a/CraftStore_Migrations.lua
+++ b/CraftStore_Migrations.lua
@@ -1,0 +1,136 @@
+local CS = CraftStoreFixedAndImprovedLongClassName
+
+-- With Gold Road, ZOS swapped the indices of ring and necklace
+-- Migration of values in CS.Account.crafting.stored[7]
+function CS.MigrateJewelryIdSwap()
+    local function LinkedItemIsCheaperThanCurrentItemAndShouldReplaceIt(link, craft, line, trait)
+        local q1, l1, v1 = GetItemLinkQuality(link), GetItemLinkRequiredLevel(link), GetItemLinkRequiredChampionPoints(link)
+
+        -- safety check due to Dragonhold quests
+        if CS.NilCheck(CS.Account.crafting.stored, {}, craft, line, trait) == {} then
+            return true
+        elseif CS.Account.crafting.stored[craft][line][trait] == nil or not CS.Account.crafting.stored[craft][line][trait].link then
+            return true
+        else
+            local q2 = GetItemLinkQuality(CS.Account.crafting.stored[craft][line][trait].link)
+            local l2 = GetItemLinkRequiredLevel(CS.Account.crafting.stored[craft][line][trait].link)
+            local v2 = GetItemLinkRequiredChampionPoints(CS.Account.crafting.stored[craft][line][trait].link)
+            if q1 < q2 then
+                return true
+            end
+            if l1 < l2 then
+                return true
+            end
+            if v1 < v2 then
+                return true
+            end
+            return false
+        end
+    end
+
+    local function deepcopy(orig)
+        local orig_type = type(orig)
+        local copy
+        if orig_type == 'table' then
+            copy = {}
+            for orig_key, orig_value in next, orig, nil do
+                copy[deepcopy(orig_key)] = deepcopy(orig_value)
+            end
+            setmetatable(copy, deepcopy(getmetatable(orig)))
+        else -- number, string, boolean, etc
+            copy = orig
+        end
+        return copy
+    end
+
+    local function tablelength(T)
+        local count = 0
+        for _ in pairs(T) do count = count + 1 end
+        return count
+    end
+
+    -- craft jewelry
+    local jewelryCraft = 7
+
+    -- safety check
+    if CS.Account.crafting.stored[jewelryCraft] == nil then
+        df("CS.Account.crafting.stored[" .. tostring(jewelryCraft) .. "] not accessible. Skipping migration.")
+        return
+    end
+
+    local oldNecklaceLine = 1
+    local oldRingLine = 2
+    local newNecklaceLine = 2
+    local newRingLine = 1
+    local cache = nil
+
+    for trait = 1, tablelength(CS.Account.crafting.stored[jewelryCraft][oldNecklaceLine]) do
+        local oldNecklaceTraitData = CS.Account.crafting.stored[jewelryCraft][oldNecklaceLine][trait]
+        local oldRingTraitData = CS.Account.crafting.stored[jewelryCraft][oldRingLine][trait]
+
+        if CS.Debug then 
+            df("trait "..tostring(trait)) 
+            df("line 1: "..tostring(oldNecklaceTraitData))
+            df("line 2: "..tostring(oldRingTraitData))
+        end
+        local actualLineOfOldNecklaceTraitData, actualLineOfOldRingTraitData = 0, 0
+
+        if oldNecklaceTraitData.link ~= nil then
+            _, actualLineOfOldNecklaceTraitData, _ = CS.GetTrait(oldNecklaceTraitData.link)
+        end
+        if oldRingTraitData.link ~= nil then
+            _, actualLineOfOldRingTraitData, _ = CS.GetTrait(oldRingTraitData.link)
+        end
+
+        if actualLineOfOldNecklaceTraitData == 0 then
+            -- line1 empty and line2 empty skipped, nothing to do
+            if actualLineOfOldRingTraitData ~= 0 then -- line1 empty and line2 not empty
+                if CS.Debug then df("line1 empty and line2 not empty") end
+                if actualLineOfOldRingTraitData == newRingLine then
+                    if CS.Debug then df("actualLineOfOldRingTraitData: "..tostring(actualLineOfOldRingTraitData).." == newRingLine: "..tostring(newRingLine)) end
+                    CS.Account.crafting.stored[jewelryCraft][newRingLine][trait] = deepcopy(oldRingTraitData)
+                    CS.Account.crafting.stored[jewelryCraft][oldRingLine][trait] = {}
+                end
+            end
+        else
+            if actualLineOfOldRingTraitData == 0 then -- line1 not empty and line2 empty
+                if CS.Debug then df("line1 not empty and line2 empty") end
+                if actualLineOfOldNecklaceTraitData == newNecklaceLine then
+                    if CS.Debug then df("actualLineOfOldNecklaceTraitData: "..tostring(actualLineOfOldNecklaceTraitData).." == newNecklaceLine: "..tostring(newNecklaceLine)) end
+                    CS.Account.crafting.stored[jewelryCraft][newNecklaceLine][trait] = deepcopy(oldNecklaceTraitData)
+                    CS.Account.crafting.stored[jewelryCraft][oldNecklaceLine][trait] = {}
+                end
+            else -- line1 not empty and line2 not empty
+                if CS.Debug then df("line1 not empty and line2 not empty") end
+                -- line1 wrong and line2 wrong => swap entries
+                if actualLineOfOldRingTraitData == newNecklaceLine and actualLineOfOldNecklaceTraitData == newRingLine then 
+                    if CS.Debug then df("line1 wrong and line2 wrong => swap entries") end
+                    cache = deepcopy(oldNecklaceTraitData)
+                    CS.Account.crafting.stored[jewelryCraft][newRingLine][trait] = deepcopy(oldRingTraitData)
+                    CS.Account.crafting.stored[jewelryCraft][newNecklaceLine][trait] = cache
+
+                    -- line1 wrong and line2 correct => two actions:
+                    --   1. Compare entries of line1 and line2. If entry from line1 is cheaper than current entry in line2: replace entry of line2 with entry of line1
+                    --   2. Clear line1
+                elseif actualLineOfOldRingTraitData == newNecklaceLine and actualLineOfOldNecklaceTraitData == newNecklaceLine then
+                    if CS.Debug then df("line1 wrong and line2 correct") end
+                    if LinkedItemIsCheaperThanCurrentItemAndShouldReplaceIt(oldNecklaceTraitData.link, jewelryCraft, newNecklaceLine, trait) then
+                        CS.Account.crafting.stored[jewelryCraft][newNecklaceLine][trait] = deepcopy(oldNecklaceTraitData)
+                    end
+                    CS.Account.crafting.stored[jewelryCraft][oldNecklaceLine][trait] = {}
+
+                    -- line1 correct and line2 wrong => two actions:
+                    --   1. Compare entries of line1 and line2. If entry from line2 is cheaper than current entry in line1: replace entry of line1 with entry of line2
+                    --   2. Clear line2
+                elseif actualLineOfOldRingTraitData == newRingLine and actualLineOfOldNecklaceTraitData == newRingLine then
+                    if CS.Debug then df("line1 correct and line2 wrong") end
+                    if LinkedItemIsCheaperThanCurrentItemAndShouldReplaceIt(oldRingTraitData.link, jewelryCraft, newRingLine, trait) then
+                        CS.Account.crafting.stored[jewelryCraft][newRingLine][trait] = deepcopy(oldRingTraitData)
+                    end
+                    CS.Account.crafting.stored[jewelryCraft][oldRingLine][trait] = {}
+                end
+                -- line1 correct and line2 correct => do nothing
+            end
+        end
+    end
+end

--- a/CraftStore_Styles.lua
+++ b/CraftStore_Styles.lua
@@ -491,7 +491,7 @@ function CS.STYLE()
 		elseif not styles[style] then 
 			local link = GetItemStyleMaterialLink(style)
 			local icon = GetItemLinkInfo(link)
-			name = zo_strformat('<<C:1>>',GetItemStyleName(style))
+			local name = zo_strformat('<<C:1>>',GetItemStyleName(style))
 			if name ~= "None" and name ~= "" then
 				return true 
 			else
@@ -506,7 +506,7 @@ function CS.STYLE()
 		local name, aName, aLink, popup
 		local link = GetItemStyleMaterialLink(style)
 		local icon = GetItemLinkInfo(link)
-		name = zo_strformat('<<C:1>>',GetItemStyleName(style))
+		local name = zo_strformat('<<C:1>>',GetItemStyleName(style))
 		--Check for undefined names
 		if name:find("Unused") then
 			for index,data in pairs (CS.Loc.styleNames) do

--- a/CraftStore_VarInit.lua
+++ b/CraftStore_VarInit.lua
@@ -290,7 +290,7 @@ CS.Mount = {
 
 -- Script for printing the latest wayshrines, 494 is one of the last Deadlands wayshrine nodes
 --for i=494, GetNumFastTravelNodes() do
---  _, name = GetFastTravelNodeInfo(i)
+--  local _, name = GetFastTravelNodeInfo(i)
 --  d(i, name)
 --end
 

--- a/CraftStore_VarInit.lua
+++ b/CraftStore_VarInit.lua
@@ -394,7 +394,7 @@ CS.AccountInit = {
   storage = {},
   materials = {},
   announce = {},
-  crafting = { researched = {}, researching = {}, studies = {}, stored = {}, skill = {} },
+  crafting = { jewelryIdSwapMigrationAlreadyDone = false, researched = {}, researching = {}, studies = {}, stored = {}, skill = {} },
   style = { tracking = {}, knowledge = {} },
   cook =  { tracking = {}, knowledge = {}, ingredients = {} },
   furnisher =  { tracking = {}, knowledge = {}, ingredients = {} },


### PR DESCRIPTION
With Gold Road, the indices of rings and necklaces for the crafting bench changed.

Here's what still works with the game update:

- Checkmarks for learned traits are still shown correctly

Here's what the game update broke:

- Tooltips have wrong information (e.g. a ring might show as not yet researched when it's actually the necklace that's missing)
- Wrong items are marked in the CraftStore grid as being available in inventory (e.g. it might show an exemplary ring from your inventory when hovering over the missing necklace trait)
- No jewelry items can be researched via the CraftStore interface anymore whatsoever (via middle mouse button), even when there is a suitable item and even when the trait is missing for both ring and necklace (e.g. it tries to use a ring item to research a necklace trait and fails with "No free research slot or item inaccessible!" error)

According to my tests, the change in line 3192 fixed all three issues. Unless there's any additional bugs that I didn't test, the change should fix all jewelry again.

The remaining changes are merely to keep all mentions of rings and necklaces in the code consistent with the new order, but aren't actually changing any functionality.