### PR TITLE
fix: add missing `end` to OnCraftingStationInteract function

### DIFF
--- a/CraftStore_Events.lua
+++ b/CraftStore_Events.lua
@@ -67,6 +67,7 @@ function CS.OnCraftingStationInteract(eventCode,craftSkill)
       end
 
       CS.Cook.hooksInitialized = true
+    end
   end
   if CS.Account.options.userune and craftSkill == CRAFTING_TYPE_ENCHANTING then
       CS.Extern = false


### PR DESCRIPTION
Adds a missing `end` to the `OnCraftingStationInteract` function to resolve
a syntax conflict and ensure proper block closure.

- Fixes a syntax error caused by the missing `end`.
- Ensures the function is correctly structured.